### PR TITLE
Monday.com works again

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ keywords = [
 license = "Apache 2.0"
 
 [tool.poetry.dependencies]
-python = ">=3.7.1,<3.11"
-requests = "^2.25.1"
-singer-sdk = "^0.7.0"
+python = ">=3.9"
+requests = "==2.32.2"
+singer-sdk = { version="~=0.43.1" }
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/tap_monday/client.py
+++ b/tap_monday/client.py
@@ -108,3 +108,8 @@ class MondayStream(GraphQLStream):
             finished = not next_page_token
 
         self.log_sync_costs()
+
+    def prepare_request(self, context: Optional[dict], next_page_token: Optional[Any]) -> requests.PreparedRequest:
+        prepared_request = super().prepare_request(context, next_page_token)
+        self.logger.info(f"Request payload: {prepared_request.body}")
+        return prepared_request

--- a/tap_monday/streams.py
+++ b/tap_monday/streams.py
@@ -80,6 +80,8 @@ class BoardsStream(MondayStream):
                 th.Property("id", th.StringType),
                 th.Property("type", th.StringType),
                 th.Property("value", th.StringType),
+                # Allow BoardRelationValue to have linked_item_ids
+                th.Property("linked_item_ids", th.ArrayType(th.StringType, description="List of linked item IDs", default=[])),
             ))),
         ))),  # Updated to match the new structure
     ).to_dict()
@@ -415,6 +417,8 @@ class ItemsStream(MondayStream):
             th.Property("id", th.StringType),
             th.Property("type", th.StringType),
             th.Property("value", th.StringType),
+            # Allow BoardRelationValue to have linked_item_ids
+            th.Property("linked_item_ids", th.ArrayType(th.StringType, description="List of linked item IDs", default=[]
         ))),
     ).to_dict()
 

--- a/tap_monday/streams.py
+++ b/tap_monday/streams.py
@@ -64,7 +64,7 @@ class BoardsStream(MondayStream):
         th.Property("updated_at", th.DateTimeType),
         th.Property("workspace_id", th.StringType),  # Allow string type for workspace_id
         th.Property("items", th.ArrayType(th.ObjectType(
-             th.Property("id", th.StringType, description="The unique ID of the item"),
+            th.Property("id", th.StringType, description="The unique ID of the item"),
             th.Property("name", th.StringType, description="The name of the item"),
             th.Property("created_at", th.DateTimeType, description="The item's creation date"),
             th.Property("creator_id", th.StringType, description="The unique identifier of the item's creator"),
@@ -404,16 +404,23 @@ class ItemsStream(MondayStream):
         th.Property("board_id", th.StringType, description="The ID of the parent board"),
         th.Property("group_id", th.StringType, description="The ID of the group the item belongs to"),
         th.Property("state", th.StringType, description="The state of the item"),
-        th.Property("creator_id", th.StringType, description="The ID of the user who created the item"),
-        th.Property("created_at", th.DateTimeType, description="The creation timestamp of the item"),
         th.Property("updated_at", th.DateTimeType, description="The last updated timestamp of the item"),
+        th.Property("created_at", th.DateTimeType, description="The item's creation date"),
+        th.Property("creator_id", th.StringType, description="The unique identifier of the item's creator"),
+        th.Property("email", th.StringType, description="The item's email"),
+        th.Property("relative_link", th.StringType, description="The item's relative path"),
+        th.Property("state", th.StringType, description="The state of the item"),
+        th.Property("updated_at", th.DateTimeType, description="The date the item was last updated"),
+        th.Property("url", th.StringType, description="The item's URL"),
         th.Property("column_values", th.ArrayType(th.ObjectType(
             th.Property("column", th.ObjectType(
-                th.Property("title", th.StringType, description="The title of the column"),
+                th.Property("id", th.StringType),
+                th.Property("title", th.StringType),
             )),
-            th.Property("text", th.StringType, description="The text value of the column"),
-            th.Property("value", th.StringType, description="The raw value of the column"),
-        )), description="The column values of the item"),
+            th.Property("id", th.StringType),
+            th.Property("type", th.StringType),
+            th.Property("value", th.StringType),
+        ))),
     ).to_dict()
 
     @property
@@ -427,20 +434,20 @@ class ItemsStream(MondayStream):
                         items {
                             id
                             name
-                            group {
-                                id
-                            }
-                            state
-                            creator {
-                                id
-                            }
                             created_at
+                            creator_id
+                            email
+                            relative_link
+                            state
                             updated_at
+                            url
                             column_values {
                                 column {
+                                    id
                                     title
                                 }
-                                text
+                                id
+                                type
                                 value
                             }
                         }

--- a/tap_monday/streams.py
+++ b/tap_monday/streams.py
@@ -119,6 +119,9 @@ class BoardsStream(MondayStream):
                                 }
                                 id
                                 type
+                                ... on BoardRelationValue {
+                                    linked_item_ids
+                                }
                                 value
                             }
                         }

--- a/tap_monday/streams.py
+++ b/tap_monday/streams.py
@@ -81,7 +81,7 @@ class BoardsStream(MondayStream):
                 th.Property("type", th.StringType),
                 th.Property("value", th.StringType),
                 # Allow BoardRelationValue to have linked_item_ids
-                th.Property("linked_item_ids", th.ArrayType(th.StringType, description="List of linked item IDs", default=[])),
+                th.Property("linked_item_ids", th.ArrayType(th.StringType)),
             ))),
         ))),  # Updated to match the new structure
     ).to_dict()
@@ -418,7 +418,7 @@ class ItemsStream(MondayStream):
             th.Property("type", th.StringType),
             th.Property("value", th.StringType),
             # Allow BoardRelationValue to have linked_item_ids
-            th.Property("linked_item_ids", th.ArrayType(th.StringType, description="List of linked item IDs", default=[]
+            th.Property("linked_item_ids", th.ArrayType(th.StringType)),
         ))),
     ).to_dict()
 

--- a/tap_monday/streams.py
+++ b/tap_monday/streams.py
@@ -103,7 +103,7 @@ class BoardsStream(MondayStream):
                     updated_at
                     workspace_id
                     items_page {
-                        items {
+                        items (limit: 1000) {
                             id
                             name
                             created_at

--- a/tap_monday/streams.py
+++ b/tap_monday/streams.py
@@ -443,6 +443,9 @@ class ItemsStream(MondayStream):
                                 }
                                 id
                                 type
+                                ... on BoardRelationValue {
+                                    linked_item_ids
+                                }
                                 value
                             }
                         }

--- a/tap_monday/tap.py
+++ b/tap_monday/tap.py
@@ -13,6 +13,7 @@ from tap_monday.streams import (
     ColumnsStream,
     GroupsStream,
     UsersStream, 
+    ItemsStream,
 )
 
 STREAM_TYPES = [
@@ -22,6 +23,7 @@ STREAM_TYPES = [
     ColumnsStream,
     GroupsStream,
     UsersStream,
+    ItemsStream,
 ]
 
 

--- a/tap_monday/tap.py
+++ b/tap_monday/tap.py
@@ -12,6 +12,7 @@ from tap_monday.streams import (
     BoardViewsStream,
     ColumnsStream,
     GroupsStream,
+    UsersStream, 
 )
 
 STREAM_TYPES = [
@@ -20,6 +21,7 @@ STREAM_TYPES = [
     BoardViewsStream,
     ColumnsStream,
     GroupsStream,
+    UsersStream,
 ]
 
 


### PR DESCRIPTION

This pull request includes several changes to the `pyproject.toml`, `tap_monday/client.py`, and `tap_monday/tap.py` files. The most important changes involve updates to dependencies, the addition of a new method for logging request payloads, and the inclusion of a new stream type.

Dependency updates:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L13-R15): Updated `python` version requirement to ">=3.9", `requests` version to "==2.32.2", and `singer-sdk` version to "~=0.43.1".

New method for logging request payloads:
* [`tap_monday/client.py`](diffhunk://#diff-55db527bf79e211d3535029ab07146106bf037b1cacb9fe4886f7fc2a8c06137R111-R115): Added the `prepare_request` method to log the request payload before returning the prepared request.

Inclusion of a new stream type:
* [`tap_monday/tap.py`](diffhunk://#diff-6c9bbad1f63c6165a408c9de5cef1ba41ba0221aca31bebd78855df836520a68R15): Added `UsersStream` to the list of imported stream types and to the `STREAM_TYPES` list. [[1]](diffhunk://#diff-6c9bbad1f63c6165a408c9de5cef1ba41ba0221aca31bebd78855df836520a68R15) [[2]](diffhunk://#diff-6c9bbad1f63c6165a408c9de5cef1ba41ba0221aca31bebd78855df836520a68R24)